### PR TITLE
Fix: install.sh fails if $PATH contains a space

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -11,7 +11,7 @@ $HOME/bin
 
 for dir in $PATHDIRS
 do
-    if [ `echo $PATH | grep $dir` ]; then
+    if [ "`echo $PATH | grep $dir`" ]; then
         cp -rvf "$FILEDIR/bin" "$FILEDIR/games" $dir
         break
     fi


### PR DESCRIPTION
If a directory name in `$PATH` contains a space, `install.sh` fails:

```
$ ./install.sh
/Users/mamacdon/code/weirdfortune
./install.sh: line 14: [: /opt/local/bin:/opt/local/sbin:/usr/local/git/bin:/opt/local/bin:/opt/local/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:/usr/local/go/bin:/Users/mamacdon/some: unary operator expected
... 
```

This fixes it
